### PR TITLE
Rename ReportUtils to ErrorUtils

### DIFF
--- a/src/main/java/com/example/accommodiq/controllers/UserController.java
+++ b/src/main/java/com/example/accommodiq/controllers/UserController.java
@@ -9,14 +9,13 @@ import com.example.accommodiq.services.interfaces.IAccountService;
 import com.example.accommodiq.services.interfaces.INotificationService;
 import com.example.accommodiq.services.interfaces.IReportService;
 import com.example.accommodiq.services.interfaces.IUserService;
-import com.example.accommodiq.utilities.ReportUtils;
+import com.example.accommodiq.utilities.ErrorUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collection;
 
@@ -94,7 +93,7 @@ public class UserController {
         Account account = (Account) accountService.loadUserByUsername(email);
 
         if (!passwordEncoder.matches(passwordDto.getOldPassword(), account.getPassword())) {
-            ReportUtils.throwBadRequest("wrongOldPassword");
+            ErrorUtils.throwBadRequest("wrongOldPassword");
         }
 
         passwordDto.encode(passwordEncoder);

--- a/src/main/java/com/example/accommodiq/domain/Accommodation.java
+++ b/src/main/java/com/example/accommodiq/domain/Accommodation.java
@@ -4,9 +4,8 @@ import com.example.accommodiq.dtos.AccommodationCreateDto;
 import com.example.accommodiq.dtos.AccommodationUpdateDto;
 import com.example.accommodiq.enums.AccommodationStatus;
 import com.example.accommodiq.enums.PricingType;
-import com.example.accommodiq.utilities.ReportUtils;
+import com.example.accommodiq.utilities.ErrorUtils;
 import jakarta.persistence.*;
-import org.hibernate.Hibernate;
 
 import java.util.*;
 
@@ -264,11 +263,11 @@ public class Accommodation {
         }
 
         if (!isAvailable(fromDate, toDate)) {
-            ReportUtils.throwBadRequest("accommodationUnavailable");
+            ErrorUtils.throwBadRequest("accommodationUnavailable");
         }
 
         if (pricingType == PricingType.PER_GUEST && (guests > maxGuests || guests < minGuests)) {
-            ReportUtils.throwBadRequest("invalidGuestNumber");
+            ErrorUtils.throwBadRequest("invalidGuestNumber");
         }
 
         Long oneDay = (long) (60 * 60 * 24);

--- a/src/main/java/com/example/accommodiq/services/AccommodationServiceImpl.java
+++ b/src/main/java/com/example/accommodiq/services/AccommodationServiceImpl.java
@@ -13,7 +13,7 @@ import com.example.accommodiq.services.interfaces.IAccommodationService;
 import jakarta.persistence.EntityNotFoundException;
 import org.hibernate.exception.ConstraintViolationException;
 import com.example.accommodiq.specifications.AccommodationSpecification;
-import com.example.accommodiq.utilities.ReportUtils;
+import com.example.accommodiq.utilities.ErrorUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -26,7 +26,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.Instant;
 import java.util.*;
 
-import static com.example.accommodiq.utilities.ReportUtils.throwNotFound;
+import static com.example.accommodiq.utilities.ErrorUtils.throwNotFound;
 
 
 @Service
@@ -121,7 +121,7 @@ public class AccommodationServiceImpl implements IAccommodationService {
         Optional<Accommodation> accommodation = accommodationRepository.findById(accommodationId);
 
         if (accommodation.isEmpty()) {
-            ReportUtils.throwNotFound("accommodationNotFound");
+            ErrorUtils.throwNotFound("accommodationNotFound");
         }
 
         return new AccommodationDetailsDto(accommodation.get());

--- a/src/main/java/com/example/accommodiq/services/AccountServiceImpl.java
+++ b/src/main/java/com/example/accommodiq/services/AccountServiceImpl.java
@@ -14,8 +14,7 @@ import com.example.accommodiq.repositories.AccountRepository;
 import com.example.accommodiq.services.interfaces.IAccountService;
 import com.example.accommodiq.services.interfaces.IEmailService;
 import com.example.accommodiq.services.interfaces.INotificationSettingService;
-import com.example.accommodiq.utilities.ReportUtils;
-import jakarta.persistence.EntityManager;
+import com.example.accommodiq.utilities.ErrorUtils;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -88,7 +87,7 @@ public class AccountServiceImpl implements IAccountService {
         } catch (ConstraintViolationException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Account cannot be inserted");
         }
-        emailService.sendVerificationEmail(account.getId(),account.getEmail());
+        emailService.sendVerificationEmail(account.getId(), account.getEmail());
         notificationSettingService.setNotificationSettingsForUser(account.getUser().getId());
     }
 
@@ -135,7 +134,7 @@ public class AccountServiceImpl implements IAccountService {
 //        return new UserLoginDto(account);
 
         if (credentialsDto.getEmail().equals("test@nonexistent.com")) {
-            ReportUtils.throwNotFound("badCredentials");
+            ErrorUtils.throwNotFound("badCredentials");
         }
 
         return new UserLoginDto(new User(

--- a/src/main/java/com/example/accommodiq/services/GuestServiceImpl.java
+++ b/src/main/java/com/example/accommodiq/services/GuestServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.accommodiq.services;
 
 import com.example.accommodiq.domain.Accommodation;
-import com.example.accommodiq.domain.Account;
 import com.example.accommodiq.domain.Guest;
 import com.example.accommodiq.domain.Reservation;
 import com.example.accommodiq.dtos.*;
@@ -9,7 +8,7 @@ import com.example.accommodiq.enums.ReservationStatus;
 import com.example.accommodiq.repositories.AccommodationRepository;
 import com.example.accommodiq.repositories.GuestRepository;
 import com.example.accommodiq.services.interfaces.IGuestService;
-import com.example.accommodiq.utilities.ReportUtils;
+import com.example.accommodiq.utilities.ErrorUtils;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
@@ -33,7 +32,7 @@ public class GuestServiceImpl implements IGuestService {
         Optional<Guest> guest = guestRepository.findById(guestId);
 
         if (guest.isEmpty()) {
-            ReportUtils.throwNotFound("guestNotFound");
+            ErrorUtils.throwNotFound("guestNotFound");
         }
 
         return guest.get();
@@ -43,7 +42,7 @@ public class GuestServiceImpl implements IGuestService {
         Optional<Accommodation> accommodation = accommodationRepository.findById(accommodationId);
 
         if (accommodation.isEmpty()) {
-            ReportUtils.throwNotFound("accommodationNotFound");
+            ErrorUtils.throwNotFound("accommodationNotFound");
         }
 
         return accommodation.get();
@@ -52,7 +51,7 @@ public class GuestServiceImpl implements IGuestService {
     @Override
     public Collection<ReservationListDto> getReservations(Long guestId) {
         if (guestId == 4L) {
-            ReportUtils.throwNotFound("guestNotFound");
+            ErrorUtils.throwNotFound("guestNotFound");
         }
 
         ArrayList<ReservationListDto> reservationListDtos = new ArrayList<>();
@@ -119,7 +118,7 @@ public class GuestServiceImpl implements IGuestService {
     @Override
     public Collection<AccommodationListDto> getFavorites(Long guestId) {
         if (guestId == 4L) {
-            ReportUtils.throwNotFound("guestNotFound");
+            ErrorUtils.throwNotFound("guestNotFound");
         }
 
         ArrayList<AccommodationListDto> accommodationListDtos = new ArrayList<>();
@@ -157,7 +156,7 @@ public class GuestServiceImpl implements IGuestService {
     @Override
     public AccommodationListDto addFavorite(Long guestId, GuestFavoriteDto favoriteDto) {
         if (guestId == 4L) {
-            ReportUtils.throwNotFound("guestNotFound");
+            ErrorUtils.throwNotFound("guestNotFound");
         }
         return new AccommodationListDto() {{
             setId(2L);
@@ -175,11 +174,11 @@ public class GuestServiceImpl implements IGuestService {
     @Override
     public MessageDto removeFavorite(Long guestId, Long accommodationId) {
         if (guestId == 4L) {
-            ReportUtils.throwNotFound("guestNotFound");
+            ErrorUtils.throwNotFound("guestNotFound");
         }
 
         if (accommodationId == 4L) {
-            ReportUtils.throwNotFound("favoriteNotFound");
+            ErrorUtils.throwNotFound("favoriteNotFound");
         }
 
         return new MessageDto("Favorite removed successfully");

--- a/src/main/java/com/example/accommodiq/services/HostServiceImpl.java
+++ b/src/main/java/com/example/accommodiq/services/HostServiceImpl.java
@@ -9,7 +9,7 @@ import com.example.accommodiq.repositories.HostRepository;
 import com.example.accommodiq.services.interfaces.IAccommodationService;
 import com.example.accommodiq.repositories.AccommodationRepository;
 import com.example.accommodiq.services.interfaces.IHostService;
-import com.example.accommodiq.utilities.ReportUtils;
+import com.example.accommodiq.utilities.ErrorUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +31,7 @@ public class HostServiceImpl implements IHostService {
     AccommodationRepository allAccommodations;
 
     @Autowired
-    public HostServiceImpl(IAccommodationService accommodationService, HostRepository hostRepository,AccommodationRepository allAccommodations) {
+    public HostServiceImpl(IAccommodationService accommodationService, HostRepository hostRepository, AccommodationRepository allAccommodations) {
         this.accommodationService = accommodationService;
         this.hostRepository = hostRepository;
         this.allAccommodations = allAccommodations;
@@ -46,7 +46,7 @@ public class HostServiceImpl implements IHostService {
     public Host findHost(Long hostId) {
         Optional<Host> found = hostRepository.findById(hostId);
         if (found.isEmpty()) {
-            ReportUtils.throwNotFound("hostNotFound");
+            ErrorUtils.throwNotFound("hostNotFound");
         }
         return found.get();
     }
@@ -80,7 +80,7 @@ public class HostServiceImpl implements IHostService {
     @Override
     public ArrayList<HostReservationDto> getHostAccommodationReservations(Long hostId) {
         if (hostId == 4L) {
-            ReportUtils.throwNotFound("hostNotFound");
+            ErrorUtils.throwNotFound("hostNotFound");
         }
 
         ArrayList<HostReservationDto> reservations = new ArrayList<>();
@@ -94,7 +94,7 @@ public class HostServiceImpl implements IHostService {
     @Override
     public ArrayList<FinancialReportEntryDto> getFinancialReport(Long hostId, long fromDate, long toDate) {
         if (hostId == 4L) {
-            ReportUtils.throwNotFound("hostNotFound");
+            ErrorUtils.throwNotFound("hostNotFound");
         }
 
         ArrayList<FinancialReportEntryDto> financialReportEntries = new ArrayList<>();
@@ -109,7 +109,7 @@ public class HostServiceImpl implements IHostService {
     @Override
     public Collection<Review> getHostReviews(Long hostId) {
         if (hostId == 4L) {
-            ReportUtils.throwNotFound("hostNotFound");
+            ErrorUtils.throwNotFound("hostNotFound");
         }
 
         return new ArrayList<Review>() {
@@ -137,7 +137,7 @@ public class HostServiceImpl implements IHostService {
     @Override
     public Review addReview(Long hostId, ReviewRequestDto reviewDto) {
         if (hostId == 4L) {
-            ReportUtils.throwNotFound("hostNotFound");
+            ErrorUtils.throwNotFound("hostNotFound");
         }
 
         return new Review(1L, 5, "Great place!", new Date().getTime(), ReviewStatus.ACCEPTED);

--- a/src/main/java/com/example/accommodiq/services/NotificationServiceImpl.java
+++ b/src/main/java/com/example/accommodiq/services/NotificationServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.accommodiq.services;
 
 import com.example.accommodiq.domain.Notification;
-import com.example.accommodiq.domain.NotificationSetting;
 import com.example.accommodiq.domain.User;
 import com.example.accommodiq.repositories.NotificationRepository;
 import com.example.accommodiq.services.interfaces.INotificationService;
@@ -13,11 +12,11 @@ import org.springframework.stereotype.Service;
 import java.util.Collection;
 import java.util.Optional;
 
-import static com.example.accommodiq.utilities.ReportUtils.throwNotFound;
+import static com.example.accommodiq.utilities.ErrorUtils.throwNotFound;
 
 @Service
 public class NotificationServiceImpl implements INotificationService {
-    
+
     final
     NotificationRepository allNotifications;
 

--- a/src/main/java/com/example/accommodiq/services/NotificationSettingServiceImpl.java
+++ b/src/main/java/com/example/accommodiq/services/NotificationSettingServiceImpl.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import java.util.Collection;
 import java.util.Optional;
 
-import static com.example.accommodiq.utilities.ReportUtils.throwNotFound;
+import static com.example.accommodiq.utilities.ErrorUtils.throwNotFound;
 
 @Service
 public class NotificationSettingServiceImpl implements INotificationSettingService {

--- a/src/main/java/com/example/accommodiq/services/ReportServiceImpl.java
+++ b/src/main/java/com/example/accommodiq/services/ReportServiceImpl.java
@@ -14,8 +14,8 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.example.accommodiq.utilities.ReportUtils.throwBadRequest;
-import static com.example.accommodiq.utilities.ReportUtils.throwNotFound;
+import static com.example.accommodiq.utilities.ErrorUtils.throwBadRequest;
+import static com.example.accommodiq.utilities.ErrorUtils.throwNotFound;
 
 @Service
 public class ReportServiceImpl implements IReportService {
@@ -134,5 +134,5 @@ public class ReportServiceImpl implements IReportService {
         report.setTimestamp(reportDto.getTimestamp());
         return report;
     }
-    
+
 }

--- a/src/main/java/com/example/accommodiq/services/ReviewServiceImpl.java
+++ b/src/main/java/com/example/accommodiq/services/ReviewServiceImpl.java
@@ -3,15 +3,13 @@ package com.example.accommodiq.services;
 import com.example.accommodiq.domain.Host;
 import com.example.accommodiq.domain.Review;
 import com.example.accommodiq.dtos.MessageDto;
-import com.example.accommodiq.dtos.ReviewDto;
-import com.example.accommodiq.dtos.ReviewRequestDto;
 import com.example.accommodiq.dtos.ReviewStatusDto;
 import com.example.accommodiq.enums.ReviewStatus;
 import com.example.accommodiq.repositories.ReviewRepository;
 import com.example.accommodiq.services.interfaces.IAccommodationService;
 import com.example.accommodiq.services.interfaces.IHostService;
 import com.example.accommodiq.services.interfaces.IReviewService;
-import com.example.accommodiq.utilities.ReportUtils;
+import com.example.accommodiq.utilities.ErrorUtils;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,7 +18,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.example.accommodiq.utilities.ReportUtils.throwNotFound;
+import static com.example.accommodiq.utilities.ErrorUtils.throwNotFound;
 
 @Service
 public class ReviewServiceImpl implements IReviewService {
@@ -79,7 +77,7 @@ public class ReviewServiceImpl implements IReviewService {
 //        return review;
 
         if (reviewId == 4L) {
-            ReportUtils.throwNotFound("reviewNotFound");
+            ErrorUtils.throwNotFound("reviewNotFound");
         }
 
         return new MessageDto("Review successfully deleted.");
@@ -99,7 +97,7 @@ public class ReviewServiceImpl implements IReviewService {
 //        allReviews.flush();
 
         if (reviewId == 4L) {
-            ReportUtils.throwNotFound("reviewNotFound");
+            ErrorUtils.throwNotFound("reviewNotFound");
         }
 
         return new Review(

--- a/src/main/java/com/example/accommodiq/utilities/ErrorUtils.java
+++ b/src/main/java/com/example/accommodiq/utilities/ErrorUtils.java
@@ -6,7 +6,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ResourceBundle;
 
-public class ReportUtils {
+public class ErrorUtils {
 
     private static final ResourceBundle bundle = ResourceBundle.getBundle("ValidationMessages", LocaleContextHolder.getLocale());
 


### PR DESCRIPTION
This PR renames the ReportUtils class to ErrorUtils to better match the semantics of the class.