### PR TITLE
Fix: Entity ID generator

### DIFF
--- a/src/main/java/com/example/accommodiq/domain/Accommodation.java
+++ b/src/main/java/com/example/accommodiq/domain/Accommodation.java
@@ -11,7 +11,7 @@ import java.util.*;
 @Entity
 public class Accommodation {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String title;
     private String description;

--- a/src/main/java/com/example/accommodiq/domain/Account.java
+++ b/src/main/java/com/example/accommodiq/domain/Account.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 @Entity
 public class Account implements UserDetails {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String email;
     private String password;

--- a/src/main/java/com/example/accommodiq/domain/Availability.java
+++ b/src/main/java/com/example/accommodiq/domain/Availability.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 @Entity
 public class Availability {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long fromDate;
     private Long toDate;

--- a/src/main/java/com/example/accommodiq/domain/Notification.java
+++ b/src/main/java/com/example/accommodiq/domain/Notification.java
@@ -8,7 +8,7 @@ import java.time.Instant;
 @Entity
 public class Notification {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String text;

--- a/src/main/java/com/example/accommodiq/domain/NotificationSetting.java
+++ b/src/main/java/com/example/accommodiq/domain/NotificationSetting.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 @Entity
 public class NotificationSetting {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private NotificationType type;

--- a/src/main/java/com/example/accommodiq/domain/Report.java
+++ b/src/main/java/com/example/accommodiq/domain/Report.java
@@ -8,7 +8,7 @@ import java.time.Instant;
 @Entity
 public class Report {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String reason;
     private Long timestamp;

--- a/src/main/java/com/example/accommodiq/domain/Reservation.java
+++ b/src/main/java/com/example/accommodiq/domain/Reservation.java
@@ -8,7 +8,7 @@ import jakarta.persistence.*;
 @Entity
 public class Reservation {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long startDate;
     private Long endDate;

--- a/src/main/java/com/example/accommodiq/domain/Review.java
+++ b/src/main/java/com/example/accommodiq/domain/Review.java
@@ -10,7 +10,7 @@ import java.time.Instant;
 @Entity
 public class Review {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     public Long id;
     private int rating;
     private String comment;

--- a/src/main/java/com/example/accommodiq/domain/User.java
+++ b/src/main/java/com/example/accommodiq/domain/User.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 @Inheritance(strategy = InheritanceType.JOINED)
 public class User {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String firstName;
     private String lastName;


### PR DESCRIPTION
### Description
This pull request updates the ID generation strategy from GenerationType.AUTO to GenerationType.IDENTITY. This change addresses the issue of data integrity errors encountered when inserting new records into the database.

### Problem Description
When new records were being inserted into the database, the ID was defaulting to 1 due to the use of GenerationType.AUTO. This caused a data integrity error as there were already records in the database with an existing ID of 1, after database was recreated.

### Solution
With GenerationType.IDENTITY, the database will be responsible for generating a unique ID for each new record. This approach ensures that the new ID will not conflict with existing IDs in the database.